### PR TITLE
fix: added onExit call during setState

### DIFF
--- a/lib/src/state_machine.dart
+++ b/lib/src/state_machine.dart
@@ -117,9 +117,11 @@ class StateMachine<T> extends Component {
   }
 
   /// Sets the current state immediately and calls its [onEnter] method.
+  /// Calls [onExit] on the previous state if applicable.
   void setState(State<T>? state) {
     if (state == _currentState) return;
     onTransition?.call(_owner, _currentState, state);
+    _currentState?.onExit(_owner, state);
     state?.onEnter(_owner, _currentState);
     _previousState = _currentState;
     _currentState = state;

--- a/lib/src/state_machine.dart
+++ b/lib/src/state_machine.dart
@@ -141,7 +141,6 @@ class StateMachine<T> extends Component {
       final toState = transition.to is AnyState<T>
           ? previousState
           : transition.to;
-      _currentState?.onExit(_owner, toState);
       setState(toState);
       break;
     }


### PR DESCRIPTION
## Issue
Hi, appreciate your amazing work on `flame_state_machine`! loving the clean API you've designed. However, I noticed that `setState()` doesn't call `onExit` on the previous state, not sure whether that was intentional? Anyways here's a just a PR for that one line fix. Also, would love to contribute more on this project, perhaps an option for a event-driven transition API?

## Description of Changes
- Added  `currentState?.onExit` call when calling `setState()`